### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Common tasks for [Invoke](http://www.pyinvoke.org/) that are needed again and ag
  [![Coveralls](https://img.shields.io/coveralls/jhermann/rituals.svg)](https://coveralls.io/r/jhermann/rituals)
  [![GitHub Issues](https://img.shields.io/github/issues/jhermann/rituals.svg)](https://github.com/jhermann/rituals/issues)
  [![License](https://img.shields.io/pypi/l/rituals.svg)](https://github.com/jhermann/rituals/blob/master/LICENSE)
- [![Development Status](https://pypip.in/status/rituals/badge.svg)](https://pypi.python.org/pypi/rituals/)
+ [![Development Status](https://img.shields.io/pypi/status/rituals.svg)](https://pypi.python.org/pypi/rituals/)
  [![Latest Version](https://img.shields.io/pypi/v/rituals.svg)](https://pypi.python.org/pypi/rituals/)
- [![Download format](https://pypip.in/format/rituals/badge.svg)](https://pypi.python.org/pypi/rituals/)
+ [![Download format](https://img.shields.io/pypi/format/rituals.svg)](https://pypi.python.org/pypi/rituals/)
  [![Downloads](https://img.shields.io/pypi/dw/rituals.svg)](https://pypi.python.org/pypi/rituals/)
 
 ## Overview


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20rituals))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `rituals`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.